### PR TITLE
fix: add /v2 to go module path to conform to go mod requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 out/
+godjot

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sivukhin/godjot
+module github.com/sivukhin/godjot/v2
 
 go 1.23
 


### PR DESCRIPTION
When we move past v1, go modules requires adding the major version to the go.mod path. This PR addresses that.