### PR TITLE
adds the child ordinality to each node

### DIFF
--- a/djot_html/html_writer_test.go
+++ b/djot_html/html_writer_test.go
@@ -84,7 +84,8 @@ func TestStartSymbol(t *testing.T) {
 		_ = BuildDjotAst(djotExample)
 	}
 	symbols := make([]byte, 0)
-	for s := range djot_tokenizer.StartSymbols {
+	tok := djot_tokenizer.New()
+	for s := range tok.StartSymbols {
 		if !tokenizer.SpaceNewLineByteMask.Has(s) {
 			symbols = append(symbols, s)
 		}

--- a/djot_parser/djot_ast.go
+++ b/djot_parser/djot_ast.go
@@ -400,7 +400,16 @@ func BuildDjotAst(document []byte) []TreeNode[DjotNode] {
 	tokens := djot_tokenizer.BuildDjotTokens(document)
 	context := BuildDjotContext(document, tokens)
 	ast := buildDjotAst(document, context, DjotLocalContext{}, tokens)
+	updateIndexes(ast[:])
 	return ast
+}
+
+func updateIndexes(tree []TreeNode[DjotNode]) {
+	for i, n := range tree {
+		n.Index = i
+		updateIndexes(n.Children[:])
+		tree[i] = n
+	}
 }
 
 func isTight(list tokenizer.TokenList[djot_tokenizer.DjotToken]) bool {

--- a/djot_parser/tree.go
+++ b/djot_parser/tree.go
@@ -7,6 +7,7 @@ type TreeNode[T ~int] struct {
 	Attributes tokenizer.Attributes
 	Children   []TreeNode[T]
 	Text       []byte
+	Index      int
 }
 
 func (n TreeNode[T]) Traverse(f func(node TreeNode[T])) {

--- a/djot_tokenizer/djot_inline_token.go
+++ b/djot_tokenizer/djot_inline_token.go
@@ -15,9 +15,15 @@ var (
 
 const RecordStartSymbol = true
 
-var StartSymbols = make(map[byte]struct{})
+type Tokenizer struct {
+	StartSymbols map[byte]struct{}
+}
 
-func MatchInlineToken(
+func New() Tokenizer {
+	return Tokenizer{make(map[byte]struct{})}
+}
+
+func (t Tokenizer) MatchInlineToken(
 	r tokenizer.TextReader,
 	s tokenizer.ReaderState,
 	tokenType DjotToken,
@@ -25,7 +31,7 @@ func MatchInlineToken(
 	state, ok := matchInlineToken(r, s, tokenType)
 	//goland:noinspection GoBoolExpressions
 	if RecordStartSymbol && ok && !r.IsEmpty(s) {
-		StartSymbols[r[s]] = struct{}{}
+		t.StartSymbols[r[s]] = struct{}{}
 	}
 	return state, ok
 }


### PR DESCRIPTION
I encountered a situation where a node needs to know it's ordinality among the parent's children; specifically, first and last children often have special needs. 

For example, ListNodes can contain TextNodes, or block (e.g. Paragraph) Nodes. Paragraph nodes usually render an extra blank line for white space; however, as children of ListItemNodes, we only want to render the extra blank line after the last ParagraphNode; this requires logic in the ParagraphNode to detect when it is the _last_ child of a ListItemNode, and omit the second carriage return.

`TreeNode` structs can't be compared, so to allow for Node functions to detect if the Node is the last (or first) node, this patch adds the Node ordinality to each Node. This is effectively the ID of the child within its parent; it's "position". Node Position is common in tree structure languages, such as XSLT/XPath and JsonQuery.

This PR merges cleanly onto, or under, my other PR -- there are no conflicts.