### PR TITLE
fix: add /v2 to go module path to conform to go mod requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 out/
+godjot

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 ## godjot
 
 [![Go Report Card][go-report-image]][go-report-url]
+![Go Version][go-build-badge]
 
 [go-report-image]: https://goreportcard.com/badge/github.com/sivukhin/godjot
 [go-report-url]: https://goreportcard.com/report/github.com/sivukhin/godjot
+[go-build-badge]: https://img.shields.io/github/v/tag/sivukhin/godjot?label=version&sort=semver
 
 [Djot](https://github.com/jgm/djot) markup language parser implemented in Go language
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 You can install **godjot** as a standalone binary:
 ```shell
-$> go install github.com/sivukhin/godjot@latest
+$> go install github.com/sivukhin/godjot/v2@latest
 $> echo '*Hello*, _world_' | godjot
 <p><strong>Hello</strong>, <em>world</em></p>
 ```

--- a/djot_html/djot_html.go
+++ b/djot_html/djot_html.go
@@ -5,7 +5,7 @@ import (
 
 	"maps"
 
-	. "github.com/sivukhin/godjot/djot_parser"
+	. "github.com/sivukhin/godjot/v2/djot_parser"
 )
 
 func StandaloneNodeConverter(state ConversionState[*HtmlWriter], tag string) *HtmlWriter {

--- a/djot_html/html_writer.go
+++ b/djot_html/html_writer.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strings"
 
-	. "github.com/sivukhin/godjot/djot_parser"
-	"github.com/sivukhin/godjot/djot_tokenizer"
-	"github.com/sivukhin/godjot/tokenizer"
+	. "github.com/sivukhin/godjot/v2/djot_parser"
+	"github.com/sivukhin/godjot/v2/djot_tokenizer"
+	"github.com/sivukhin/godjot/v2/tokenizer"
 )
 
 var defaultSymbolRegistry = map[string]string{}

--- a/djot_html/html_writer_bench_test.go
+++ b/djot_html/html_writer_bench_test.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"testing"
 
-	. "github.com/sivukhin/godjot/djot_parser"
+	. "github.com/sivukhin/godjot/v2/djot_parser"
 )
 
 //go:embed bench/sample01.djot

--- a/djot_html/html_writer_test.go
+++ b/djot_html/html_writer_test.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	. "github.com/sivukhin/godjot/djot_parser"
-	"github.com/sivukhin/godjot/djot_tokenizer"
-	"github.com/sivukhin/godjot/tokenizer"
+	. "github.com/sivukhin/godjot/v2/djot_parser"
+	"github.com/sivukhin/godjot/v2/djot_tokenizer"
+	"github.com/sivukhin/godjot/v2/tokenizer"
 )
 
 func printDjot(text string) string {

--- a/djot_parser/djot_ast.go
+++ b/djot_parser/djot_ast.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/sivukhin/godjot/djot_tokenizer"
-	"github.com/sivukhin/godjot/tokenizer"
+	"github.com/sivukhin/godjot/v2/djot_tokenizer"
+	"github.com/sivukhin/godjot/v2/tokenizer"
 )
 
 const (

--- a/djot_parser/djot_ast_bench_test.go
+++ b/djot_parser/djot_ast_bench_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sivukhin/godjot/djot_tokenizer"
+	"github.com/sivukhin/godjot/v2/djot_tokenizer"
 )
 
 //go:embed bench/sample01.djot

--- a/djot_parser/djot_fuzz_test.go
+++ b/djot_parser/djot_fuzz_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sivukhin/godjot/djot_tokenizer"
+	"github.com/sivukhin/godjot/v2/djot_tokenizer"
 )
 
 const examplesDir = "examples"

--- a/djot_parser/tree.go
+++ b/djot_parser/tree.go
@@ -1,6 +1,6 @@
 package djot_parser
 
-import "github.com/sivukhin/godjot/tokenizer"
+import "github.com/sivukhin/godjot/v2/tokenizer"
 
 type TreeNode[T ~int] struct {
 	Type       T

--- a/djot_tokenizer/attributes.go
+++ b/djot_tokenizer/attributes.go
@@ -1,6 +1,6 @@
 package djot_tokenizer
 
-import "github.com/sivukhin/godjot/tokenizer"
+import "github.com/sivukhin/godjot/v2/tokenizer"
 
 const (
 	DjotAttributeClassKey = "class"

--- a/djot_tokenizer/attributes_test.go
+++ b/djot_tokenizer/attributes_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sivukhin/godjot/tokenizer"
+	"github.com/sivukhin/godjot/v2/tokenizer"
 )
 
 func TestQuotedString(t *testing.T) {

--- a/djot_tokenizer/djot_block_token.go
+++ b/djot_tokenizer/djot_block_token.go
@@ -3,7 +3,7 @@ package djot_tokenizer
 import (
 	"bytes"
 
-	"github.com/sivukhin/godjot/tokenizer"
+	"github.com/sivukhin/godjot/v2/tokenizer"
 )
 
 var (

--- a/djot_tokenizer/djot_inline_token.go
+++ b/djot_tokenizer/djot_inline_token.go
@@ -1,7 +1,7 @@
 package djot_tokenizer
 
 import (
-	"github.com/sivukhin/godjot/tokenizer"
+	"github.com/sivukhin/godjot/v2/tokenizer"
 )
 
 var (

--- a/djot_tokenizer/djot_tokenizer.go
+++ b/djot_tokenizer/djot_tokenizer.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"strings"
 
-	"github.com/sivukhin/godjot/tokenizer"
+	"github.com/sivukhin/godjot/v2/tokenizer"
 )
 
 func BuildInlineDjotTokens(

--- a/djot_tokenizer/djot_tokenizer_test.go
+++ b/djot_tokenizer/djot_tokenizer_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sivukhin/godjot/tokenizer"
+	"github.com/sivukhin/godjot/v2/tokenizer"
 )
 
 func TestSimpleText(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sivukhin/godjot
+module github.com/sivukhin/godjot/v2
 
 go 1.23
 

--- a/main.go
+++ b/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/sivukhin/godjot/djot_html"
-	"github.com/sivukhin/godjot/djot_parser"
+	"github.com/sivukhin/godjot/v2/djot_html"
+	"github.com/sivukhin/godjot/v2/djot_parser"
 )
 
 func main() {


### PR DESCRIPTION
Go modules requires changing the module path when the major version > 1. This PR addresses that.

Hopefully the last version of this PR. I've never seen the last linting error; I didn't think that was valid Go syntax, but neither the compiler nor the tests caught it.